### PR TITLE
Add slurm snakemake support 

### DIFF
--- a/examples/benchmark/run_snakemake.sh
+++ b/examples/benchmark/run_snakemake.sh
@@ -15,8 +15,12 @@ snakemake --cores 1 -s "domainlab/exp_protocol/benchmark.smk" --configfile "exam
 #snakemake --rerun-incomplete --cores 1 -s "domainlab/exp_protocol/benchmark.smk" --configfile "examples/yaml/demo_benchmark.yaml"
 
 
-# print execution graph to pdf
+## Print execution graph to pdf ##
 
 #snakemake --dag --forceall -s "domainlab/exp_protocol/benchmark.smk" --configfile "examples/yaml/demo_benchmark.yaml" | dot -Tpdf > dag.pdf
 
 #snakemake --rulegraph --forceall -s "domainlab/exp_protocol/benchmark.smk" --configfile "examples/yaml/demo_benchmark.yaml" | dot -Tpdf > rulegraph.pdf
+
+## Run snakemake with slurm  ##
+
+#snakemake --profile "/home/icb/xinyue.zhang/DomainLab/examples/yaml/slurm" --keep-going --keep-incomplete --notemp --cores 5 -s "domainlab/exp_protocol/benchmark.smk" --configfile "examples/yaml/test_helm_benchmark_debug.yaml" 2>&1 | tee $logfile 

--- a/examples/yaml/slurm/config.yaml
+++ b/examples/yaml/slurm/config.yaml
@@ -1,0 +1,24 @@
+cluster:
+  mkdir -p logs/{rule} &&
+  sbatch
+    --partition=gpu_p
+    --qos=gpu
+    --gres=gpu:1
+    --nice=10000
+    -c 2
+    --mem=60G
+    --job-name=smk-{rule}-{wildcards}
+    --output=logs/{rule}/{rule}-{wildcards}-%j.out
+default-resources:
+  - partition=gpu_p
+  - qos=gpu
+  - mem_mb=1000
+restart-times: 3
+max-jobs-per-second: 10
+max-status-checks-per-second: 1
+latency-wait: 60
+jobs: 500
+keep-going: True
+printshellcmds: True
+scheduler: greedy
+use-conda: True


### PR DESCRIPTION
Example config file of running slurm from snakemake

Related PR: https://github.com/marrlab/DomainLab/pull/142
Adapted from:  https://github.com/jdblischak/smk-simple-slurm