### PR TITLE
Capture output of benchmark in file

### DIFF
--- a/examples/benchmark/run_snakemake.sh
+++ b/examples/benchmark/run_snakemake.sh
@@ -1,4 +1,16 @@
-#!/bin/sh
+#!/bin/bash
+
+timestamp() {
+#  date +"%T" # current time
+  date +"%Y-%m-%d_%H-%M-%S"
+}
+
+
+logdir="zoutput/logs"
+mkdir -p $logdir
+logfile="$logdir/$(timestamp).out"
+echo "verbose log: $logfile"
+
 # -n: dry-run  (A dry run is a software testing process where the effects of a possible failure are intentionally mitigated, For example, there is rsync utility for transfer data over some interface, but user can try rsync with dry-run option to check syntax and test communication without data transferring.)
 # -p: print shell commands
 # -d: specify working directory. This should be the DomainLab dir
@@ -12,7 +24,7 @@ export DOMAINLAB_CUDA_START_SEED=$1
 snakemake --cores 1 -s "domainlab/exp_protocol/benchmark.smk" --configfile "examples/yaml/demo_benchmark.yaml" --keep-going --summary  # this will give us a clue first what jobs will be run
 
 # second submit the jobs
-snakemake --cores 1 -s "domainlab/exp_protocol/benchmark.smk" --configfile "examples/yaml/demo_benchmark.yaml" --keep-going
+snakemake --cores 1 -s "domainlab/exp_protocol/benchmark.smk" --configfile "examples/yaml/demo_benchmark.yaml" --keep-going 2>&1 | tee "$logfile"
 
 #snakemake --rerun-incomplete --cores 1 -s "domainlab/exp_protocol/benchmark.smk" --configfile "examples/yaml/demo_benchmark.yaml"
 


### PR DESCRIPTION
Save std out and std err during benchmark to file. Helpful if errors occur, especially if later jobs filled the terminal buffer, letting the error message disappear.