### PR TITLE
benchmark: ValueError if invalid parameters are specified.

### DIFF
--- a/docs/doc_benchmark.md
+++ b/docs/doc_benchmark.md
@@ -12,9 +12,9 @@ the performance with respect to different hyperparameter choices is investigated
 The benchmark is configured in a yaml file. We refer to the
 [demo_benchmark.yaml](https://github.com/marrlab/DomainLab/blob/benchmark_snakemake/examples/yaml/demo_benchmark.yaml)
 for a documented example. As one can see here, the user has to select:
-- Common arguments for all tasks. This typically includes the dataset on which the benchmark
+- Common arguments for all tasks under `domainlab_args`. This typically includes the dataset on which the benchmark
 shall be performed, as well as the number of epochs and batch size for training.
-Here also the number of different random seeds and hyperparameter samples is set.
+- The number of different random seeds and hyperparameter samples is set.
 - The domains which are used as leave-one-out for testing.
 - Different tasks, where each task contains: (1) Fixed parameters specific for this task,
 typically the algorithm name and related arguments and (2) varying hyperparameters, for which

--- a/domainlab/arg_parser.py
+++ b/domainlab/arg_parser.py
@@ -174,13 +174,15 @@ def apply_dict_to_args(args, data: dict, extend=False):
                 cur_val = arg_dict.get(key, None)
                 if not isinstance(cur_val, list):
                     if cur_val is not None:
-                        # @FIXME: should we warn or raise Error?
-                        warnings.warn(f"input dictionary value is list, \
-                                    however, in DomainLab args, we have {cur_val}, \
-                                    going to overrite to list")
-                    arg_dict[key] = []
-                arg_dict[key].extend(value)
+                        raise RuntimeError(f"input dictionary value is list, \
+                                           however, in DomainLab args, we have {cur_val}, \
+                                           going to overrite to list")
+                    arg_dict[key] = []  # if args_dict[key] is None, cast it into a list
+                    # domainlab will take care of it if this argument can not be a list
+                arg_dict[key].extend(value)  # args_dict[key] is already a list
+                # keep existing values for the list arg_dct[key]
             else:
+                # over-write existing value
                 arg_dict[key] = value
         else:
             raise ValueError("Unsupported key: ", key)

--- a/domainlab/arg_parser.py
+++ b/domainlab/arg_parser.py
@@ -3,12 +3,13 @@ Command line arguments
 """
 import argparse
 import warnings
+
 import yaml
 
 from domainlab.algos.compos.matchdg_args import add_args2parser_matchdg
 from domainlab.algos.trainers.args_dial import add_args2parser_dial
-from domainlab.models.args_vae import add_args2parser_vae
 from domainlab.models.args_jigen import add_args2parser_jigen
+from domainlab.models.args_vae import add_args2parser_vae
 
 
 def mk_parser_main():
@@ -158,6 +159,33 @@ def mk_parser_main():
     return parser
 
 
+def apply_dict_to_args(args, data: dict, extend=False):
+    """
+    Tries to apply the data to the args dict of DomainLab.
+    Unknown keys are silently ignored as long as
+    extend is not set.
+    # FIXME: do we have a test to ensure args dict from
+    # domainlab really got what is passed from "data" dict?
+    """
+    arg_dict = args.__dict__
+    for key, value in data.items():
+        if (key in arg_dict) or extend:
+            if isinstance(value, list):
+                cur_val = arg_dict.get(key, None)
+                if not isinstance(cur_val, list):
+                    if cur_val is not None:
+                        # @FIXME: should we warn or raise Error?
+                        warnings.warn(f"input dictionary value is list, \
+                                    however, in DomainLab args, we have {cur_val}, \
+                                    going to overrite to list")
+                    arg_dict[key] = []
+                arg_dict[key].extend(value)
+            else:
+                arg_dict[key] = value
+        else:
+            raise ValueError("Unsupported key: ", key)
+
+
 def parse_cmd_args():
     """
     get args from command line
@@ -165,20 +193,9 @@ def parse_cmd_args():
     parser = mk_parser_main()
     args = parser.parse_args()
     if args.config_file:
-
         data = yaml.safe_load(args.config_file)
         delattr(args, 'config_file')
-        arg_dict = args.__dict__
-
-        for key in data:
-            if key not in arg_dict:
-                raise ValueError("The key is not supported: ", key)
-
-        for key, value in data.items():
-            if isinstance(value, list):
-                arg_dict[key].extend(value)
-            else:
-                arg_dict[key] = value
+        apply_dict_to_args(args, data)
 
     if args.acon is None:
         print("\n\n")

--- a/domainlab/arg_parser.py
+++ b/domainlab/arg_parser.py
@@ -164,8 +164,6 @@ def apply_dict_to_args(args, data: dict, extend=False):
     Tries to apply the data to the args dict of DomainLab.
     Unknown keys are silently ignored as long as
     extend is not set.
-    # FIXME: do we have a test to ensure args dict from
-    # domainlab really got what is passed from "data" dict?
     """
     arg_dict = args.__dict__
     for key, value in data.items():

--- a/examples/yaml/demo_benchmark.yaml
+++ b/examples/yaml/demo_benchmark.yaml
@@ -1,9 +1,5 @@
 # Example benchmark config script.
 
-# Arguments set here are passed to each task.
-# Specifications inside the tasks taking precedence.
-tpath: examples/tasks/task_vlcs.py  # dataset
-
 # list of all domains that are used as test domain
 # in a leave-one-out setup, i.e. for each run,
 # one domain from this list is chosen as test domain
@@ -25,14 +21,19 @@ num_param_samples: 2
 # startseed and endseed, this benchmark is fully reproducible.
 sampling_seed: 1  # Optional
 
-epos: 2
-bs: 2
 # the seed is increased by +1 until it reaches endseed.
 # endseed is included, so in total startseed - endseed + 1
 # different seeds are used to estimate the stochastic
 # variance.
 startseed: 1
 endseed: 2  # currently included
+
+domainlab_args:
+  # Domainlab arguments passed to each task.
+  # task specific arguments take precedence.
+  tpath: examples/tasks/task_vlcs.py  # dataset
+  epos: 2
+  bs: 2
 
 # Each node containing the aname property is considered as a task.
 Task_diva:  # name

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -35,6 +35,7 @@ def test_parse_yml_args():
     assert args.aname == "diva"
     assert args.gamma_y == 700000.0
 
+
 def test_parse_invalid_yml_args():
     """Test argparser with yaml file
     """
@@ -43,7 +44,7 @@ def test_parse_invalid_yml_args():
     rootdir = os.path.abspath(rootdir)
     file_path = os.path.join(rootdir, "examples/yaml/demo_invalid_parameter.yaml")
     sys.argv = ['main.py', '--config=' + file_path]
-    
+
     with pytest.raises(ValueError):
         parse_cmd_args()
 

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -2,10 +2,12 @@
 Test argparser functionality
 """
 
-import sys
 import os
+import sys
+
 import pytest
-from domainlab.arg_parser import parse_cmd_args
+
+from domainlab.arg_parser import parse_cmd_args, mk_parser_main, apply_dict_to_args
 
 
 def test_parse_cmd_args_warning():
@@ -44,3 +46,13 @@ def test_parse_invalid_yml_args():
     
     with pytest.raises(ValueError):
         parse_cmd_args()
+
+
+def test_apply_dict_to_args():
+    """Testing apply_dict_to_args"""
+    parser = mk_parser_main()
+    args = parser.parse_args(args=[])
+    data = {'a': 1, 'b': [1, 2], 'aname': 'diva'}
+    apply_dict_to_args(args, data, extend=True)
+    assert args.a == 1
+    assert args.aname == 'diva'

--- a/tests/test_run_experiment.py
+++ b/tests/test_run_experiment.py
@@ -1,11 +1,11 @@
 """
 Tests run_experiment.py
 """
+import pytest
 import torch
 import yaml
 
-from domainlab.arg_parser import mk_parser_main
-from domainlab.exp_protocol.run_experiment import run_experiment, apply_dict_to_args
+from domainlab.exp_protocol.run_experiment import run_experiment
 
 
 def test_run_experiment():
@@ -26,12 +26,6 @@ def test_run_experiment():
     config['test_domains'] = []
     run_experiment(config, param_file, param_index, out_file)
 
-
-def test_apply_dict_to_args():
-    """Testing apply_dict_to_args"""
-    parser = mk_parser_main()
-    args = parser.parse_args(args=[])
-    data = {'a': 1, 'b': [1, 2], 'aname': 'diva'}
-    apply_dict_to_args(args, data, extend=True)
-    assert args.a == 1
-    assert args.aname == 'diva'
+    config['domainlab_args']['batchsize'] = 16
+    with pytest.raises(ValueError):
+        run_experiment(config, param_file, param_index, out_file)


### PR DESCRIPTION
I implemented the proposal from here: https://github.com/marrlab/DomainLab/issues/141#issuecomment-1443658111. Maybe that's not the perfect solution, but I think it is way better than the current one.