### PR TITLE
logger instead of print

### DIFF
--- a/domainlab/algos/a_algo_builder.py
+++ b/domainlab/algos/a_algo_builder.py
@@ -1,4 +1,5 @@
 from domainlab.compos.pcr.p_chain_handler import AbstractChainNodeHandler
+from domainlab.utils.logger import Logger
 
 
 class NodeAlgoBuilder(AbstractChainNodeHandler):
@@ -11,7 +12,8 @@ class NodeAlgoBuilder(AbstractChainNodeHandler):
         """
         most algorithms do not need re-organization of data feed flow like JiGen and MatchDG
         """
-        print("processing dataset for ", args.aname)
+        logger = Logger.get_logger()
+        logger.info("processing dataset for ", args.aname)
         return ddset
 
     @property

--- a/domainlab/algos/compos/matchdg_base.py
+++ b/domainlab/algos/compos/matchdg_base.py
@@ -1,5 +1,6 @@
 import torch
 from domainlab.algos.compos.matchdg_match import MatchPair
+from domainlab.utils.logger import Logger
 
 
 class MatchAlgoBase():
@@ -95,7 +96,8 @@ def get_base_domain_size4match_dg(task):
             if task.dict_domain_class_count[domain_key][mclass] > num:
                 ref_domain = domain_key
                 num = task.dict_domain_class_count[domain_key][mclass]
-        print("for class ", mclass, " bigest sample size is ",
+        logger = Logger.get_logger()
+        logger.info("for class ", mclass, " bigest sample size is ",
               num, "ref domain is", ref_domain)
         base_domain_size += num
     return base_domain_size

--- a/domainlab/algos/compos/matchdg_ctr_erm.py
+++ b/domainlab/algos/compos/matchdg_ctr_erm.py
@@ -4,6 +4,7 @@ from domainlab.algos.compos.matchdg_base import MatchAlgoBase
 from domainlab.algos.compos.matchdg_utils import (dist_cosine_agg,
                                                   dist_pairwise_cosine)
 from domainlab.algos.trainers.a_trainer import mk_opt
+from domainlab.utils.logger import Logger
 
 
 class MatchCtrErm(MatchAlgoBase):
@@ -46,7 +47,8 @@ class MatchCtrErm(MatchAlgoBase):
         # the other part from match tensor
         """
         self.epo_loss_tr = 0
-        print(self.str_phase, "epoch", epoch)
+        logger = Logger.get_logger()
+        logger.info(self.str_phase, "epoch", epoch)
         # update match tensor
         if (epoch + 1) % self.epos_per_match == 0:
             self.mk_match_tensor(epoch)
@@ -64,8 +66,8 @@ class MatchCtrErm(MatchAlgoBase):
         self.tuple_tensor_ref_domain2each_y = torch.split(
             self.tensor_ref_domain2each_domain_y[inds_shuffle],
             self.args.bs, dim=0)
-        print("number of batches in match tensor: ", len(self.tuple_tensor_refdomain2each))
-        print("single batch match tensor size: ", self.tuple_tensor_refdomain2each[0].shape)
+        logger.info("number of batches in match tensor: ", len(self.tuple_tensor_refdomain2each))
+        logger.info("single batch match tensor size: ", self.tuple_tensor_refdomain2each[0].shape)
 
         for batch_idx, (x_e, y_e, d_e, *_) in enumerate(self.loader):
             # random loader with same batch size as the match tensor loader
@@ -73,8 +75,8 @@ class MatchCtrErm(MatchAlgoBase):
             # is only used for creating the match tensor
             self.update_batch(epoch, batch_idx, x_e, y_e, d_e)
             if self.flag_stop is True:
-                print("ref/base domain vs each domain match \
-                      traversed one sweep, starting new epoch")
+                logger.info("ref/base domain vs each domain match \
+                            traversed one sweep, starting new epoch")
                 break
         if not self.flag_erm:
             # Save ctr model's weights post each epoch
@@ -106,7 +108,8 @@ class MatchCtrErm(MatchAlgoBase):
         num_batches = len(self.tuple_tensor_refdomain2each)
 
         if batch_idx >= num_batches:
-            print("ref/base domain vs each domain match \
+            logger = Logger.get_logger()
+            logger.info("ref/base domain vs each domain match \
                     traversed one sweep, starting new epoch")
             self.flag_stop = True
             return
@@ -133,7 +136,8 @@ class MatchCtrErm(MatchAlgoBase):
         # assert not torch.sum(torch.isnan(batch_feat_ref_domain2each))
         flag_isnan = torch.any(torch.isnan(batch_feat_ref_domain2each))
         if flag_isnan:
-            print(batch_tensor_ref_domain2each)
+            logger = Logger.get_logger()
+            logger.info(batch_tensor_ref_domain2each)
             raise RuntimeError("batch_feat_ref_domain2each NAN! is learning rate too big or \
                                hyper-parameter tau not set appropriately?")
 
@@ -181,19 +185,19 @@ class MatchCtrErm(MatchAlgoBase):
 
         # Contrastive Loss: class \times domain \times domain
         counter_same_cls_diff_domain = 1
+        logger = Logger.get_logger()
         for y_c in range(self.dim_y):
 
             subset_same_cls = (batch_ref_domain2each_y[:, 0] == y_c)
             subset_diff_cls = (batch_ref_domain2each_y[:, 0] != y_c)
             feat_same_cls = batch_feat_ref_domain2each[subset_same_cls]
             feat_diff_cls = batch_feat_ref_domain2each[subset_diff_cls]
-            # print('class', y_c, "with same class and different class: ",
-            #      feat_same_cls.shape[0], feat_diff_cls.shape[0])
+            logger.debug('class', y_c, "with same class and different class: ",
+                         feat_same_cls.shape[0], feat_diff_cls.shape[0])
 
             if feat_same_cls.shape[0] == 0 or feat_diff_cls.shape[0] == 0:
-                # print("no instances of label",
-                # y_c,
-                # "in the current batch, continue")
+                logger.debug("no instances of label", y_c,
+                             "in the current batch, continue")
                 continue
 
             if torch.sum(torch.isnan(feat_diff_cls)):

--- a/domainlab/algos/compos/matchdg_match.py
+++ b/domainlab/algos/compos/matchdg_match.py
@@ -1,4 +1,5 @@
 import warnings
+from domainlab.utils.logger import Logger
 
 import numpy as np
 import torch
@@ -107,7 +108,8 @@ class MatchPair():
         # value instead of class label
         for domain in range(self.num_domains_tr):
             if self.domain_count[domain] != self.list_tr_domain_size[domain]:
-                warnings.warn("domain_count show matching \
+                logger = Logger.get_logger()
+                logger.warning("domain_count show matching \
                     dictionary missing data!")
 
     def _cal_base_domain(self):
@@ -130,9 +132,10 @@ class MatchPair():
                     base_domain_idx = domain_idx
             self.dict_cls_ind_base_domain_ind[y_c] = base_domain_idx
             # for each class label, there is a base domain
-            print("for class", y_c)
-            print("domain index as base domain:", base_domain_idx)
-            print("Base Domain size", base_domain_size)
+            logger = Logger.get_logger()
+            logger.info("for class", y_c)
+            logger.info("domain index as base domain:", base_domain_idx)
+            logger.info("Base Domain size", base_domain_size)
 
     def __call__(self, device, loader, fun_extract_semantic_feat, flag_match_min_dist):
         """
@@ -271,9 +274,10 @@ class MatchPair():
                         counter_ref_dset_size += 1
 
             if counter_ref_dset_size != self.virtual_ref_dset_size:
-                print("counter_ref_dset_size", counter_ref_dset_size)
-                print("self.virtual_ref_dset_size", self.virtual_ref_dset_size)
-                # warnings.warn("counter_ref_dset_size not equal to self.virtual_ref_dset_size")
+                logger = Logger.get_logger()
+                logger.info("counter_ref_dset_size", counter_ref_dset_size)
+                logger.info("self.virtual_ref_dset_size", self.virtual_ref_dset_size)
+                logger.warning("counter_ref_dset_size not equal to self.virtual_ref_dset_size")
                 raise RuntimeError("counter_ref_dset_size not equal to self.virtual_ref_dset_size")
 
 
@@ -292,7 +296,8 @@ class MatchPair():
                         if self.dict_virtual_dset2each_domain[key]['label'][d_i] != self.dict_virtual_dset2each_domain[key]['label'][d_j]:
                             # raise RuntimeError("the reference domain has 'rows' with inconsistent class labels")
                             wrong_case += 1
-        print('Total Label MisMatch across pairs: ', wrong_case)
+        logger = Logger.get_logger()
+        logger.info('Total Label MisMatch across pairs: ', wrong_case)
         if wrong_case != 0:
             raise RuntimeError("the reference domain \
                                has 'rows' with inconsistent class labels")
@@ -306,7 +311,7 @@ class MatchPair():
         tensor_ref_domain_each_domain_x = torch.stack(list_ref_domain_each_domain)
         tensor_ref_domain_each_domain_label = torch.stack(list_ref_domain_each_domain_label)
 
-        print(tensor_ref_domain_each_domain_x.shape, tensor_ref_domain_each_domain_label.shape)
+        logger.info(tensor_ref_domain_each_domain_x.shape, tensor_ref_domain_each_domain_label.shape)
 
         del self.dict_domain_data
         del self.dict_virtual_dset2each_domain

--- a/domainlab/algos/msels/c_msel.py
+++ b/domainlab/algos/msels/c_msel.py
@@ -3,6 +3,7 @@ Model Selection should be decoupled from
 """
 import math
 from domainlab.algos.msels.a_model_sel import AMSel
+from domainlab.utils.logger import Logger
 
 
 class MSelTrLoss(AMSel):
@@ -29,8 +30,9 @@ class MSelTrLoss(AMSel):
             self.best_loss = loss
         else:
             self.es_c += 1
-            print("early stop counter: ", self.es_c)
-            print(f"loss:{loss}, best loss: {self.best_loss}")
+            logger = Logger.get_logger()
+            logger.info("early stop counter: ", self.es_c)
+            logger.info(f"loss:{loss}, best loss: {self.best_loss}")
             flag = False  # do not update best model
         return flag
 

--- a/domainlab/algos/msels/c_msel_oracle.py
+++ b/domainlab/algos/msels/c_msel_oracle.py
@@ -2,6 +2,7 @@
 Model Selection should be decoupled from
 """
 from domainlab.algos.msels.a_model_sel import AMSel
+from domainlab.utils.logger import Logger
 
 
 class MSelOracleVisitor(AMSel):
@@ -25,7 +26,8 @@ class MSelOracleVisitor(AMSel):
         if self.tr_obs.metric_te["acc"] > self.best_oracle_acc:
             self.best_oracle_acc = self.tr_obs.metric_te["acc"]  # FIXME: only works for classification
             self.tr_obs.exp.visitor.save(self.trainer.model, "oracle")
-            print("oracle model saved")
+            logger = Logger.get_logger()
+            logger.info("oracle model saved")
         return self.msel.update()
 
     def if_stop(self):

--- a/domainlab/algos/observers/b_obvisitor.py
+++ b/domainlab/algos/observers/b_obvisitor.py
@@ -5,6 +5,7 @@ import warnings
 from domainlab.algos.observers.a_observer import AObVisitor
 from domainlab.tasks.task_folder_mk import NodeTaskFolderClassNaMismatch
 from domainlab.tasks.task_pathlist import NodeTaskPathListDummy
+from domainlab.utils.logger import Logger
 
 
 class ObVisitor(AObVisitor):
@@ -31,16 +32,17 @@ class ObVisitor(AObVisitor):
         self.perf_metric = None
 
     def update(self, epoch):
-        print("epoch:", epoch)
+        logger = Logger.get_logger()
+        logger.info("epoch:", epoch)
         self.epo = epoch
         if epoch % self.epo_te == 0:
             metric_te = self.host_trainer.model.cal_perf_metric(
                 self.loader_tr, self.device, self.loader_te)
             self.metric_te = metric_te
         if self.model_sel.update():
-            print("model selected")
+            logger.info("model selected")
             self.exp.visitor.save(self.host_trainer.model)
-            print("persisted")
+            logger.info("persisted")
         flag_stop = self.model_sel.if_stop()
         return flag_stop
 
@@ -65,7 +67,8 @@ class ObVisitor(AObVisitor):
 
         model_ld = model_ld.to(self.device)
         model_ld.eval()
-        print("persisted model performance metric: \n")
+        logger = Logger.get_logger()
+        logger.info("persisted model performance metric: \n")
         metric_te = model_ld.cal_perf_metric(self.loader_tr, self.device, self.loader_te)
         self.dump_prediction(model_ld, metric_te)
         self.exp.visitor(metric_te)

--- a/domainlab/algos/observers/c_obvisitor_gen.py
+++ b/domainlab/algos/observers/c_obvisitor_gen.py
@@ -1,5 +1,6 @@
 from domainlab.algos.observers.b_obvisitor import ObVisitor
 from domainlab.utils.flows_gen_img_model import fun_gen
+from domainlab.utils.logger import Logger
 
 
 class ObVisitorGen(ObVisitor):
@@ -8,17 +9,18 @@ class ObVisitorGen(ObVisitor):
     """
     def after_all(self):
         super().after_all()
-        print("generating images for final model at last epoch")
+        logger = Logger.get_logger()
+        logger.info("generating images for final model at last epoch")
         fun_gen(subfolder_na=self.exp.visitor.model_name+"final",
                 args=self.exp.args, node=self.exp.task, model=self.host_trainer.model, device=self.device)
 
-        print("generating images for oracle model")
+        logger.info("generating images for oracle model")
         model_or = self.exp.visitor.load("oracle")  # @FIXME: name "oracle is a strong dependency
         model_or = model_or.to(self.device)
         model_or.eval()
         fun_gen(subfolder_na=self.exp.visitor.model_name+"oracle",
                 args=self.exp.args, node=self.exp.task, model=model_or, device=self.device)
-        print("generating images for selected model")
+        logger.info("generating images for selected model")
         model_ld = self.exp.visitor.load()
         model_ld = model_ld.to(self.device)
         model_ld.eval()

--- a/domainlab/algos/trainers/train_matchdg.py
+++ b/domainlab/algos/trainers/train_matchdg.py
@@ -3,6 +3,7 @@ trainer for matchDG
 """
 from domainlab.algos.compos.matchdg_ctr_erm import MatchCtrErm
 from domainlab.algos.trainers.a_trainer import AbstractTrainer
+from domainlab.utils.logger import Logger
 
 
 class TrainerMatchDG(AbstractTrainer):
@@ -31,7 +32,8 @@ class TrainerMatchDG(AbstractTrainer):
                           flag_erm=False,
                           opt=None)
         ctr.train()
-        print("Phase 1 finished: ", ctr.ctr_mpath)
+        logger = Logger.get_logger()
+        logger.info("Phase 1 finished: ", ctr.ctr_mpath)
         # phase 2: ERM, initialize object
         self.erm = MatchCtrErm(phi=self.model,
                                exp=self.exp,

--- a/domainlab/algos/trainers/train_visitor.py
+++ b/domainlab/algos/trainers/train_visitor.py
@@ -4,6 +4,7 @@ update hyper-parameters during training
 import warnings
 import numpy as np
 from domainlab.algos.trainers.train_basic import TrainerBasic
+from domainlab.utils.logger import Logger
 
 
 class TrainerVisitor(TrainerBasic):
@@ -28,8 +29,9 @@ class TrainerVisitor(TrainerBasic):
 
     def before_tr(self):
         if self.hyper_scheduler is None:
-            warnings.warn("hyper-parameter scheduler not set, \
-                          going to use default Warmpup and epoch update")
+            logger = Logger.get_logger()
+            logger.warning("hyper-parameter scheduler not set, \
+                           going to use default Warmpup and epoch update")
             self.set_scheduler(HyperSchedulerWarmup,
                                total_steps=self.aconf.warmup,
                                flag_update_epoch=True)

--- a/domainlab/arg_parser.py
+++ b/domainlab/arg_parser.py
@@ -2,7 +2,6 @@
 Command line arguments
 """
 import argparse
-import warnings
 
 import yaml
 
@@ -10,6 +9,7 @@ from domainlab.algos.compos.matchdg_args import add_args2parser_matchdg
 from domainlab.algos.trainers.args_dial import add_args2parser_dial
 from domainlab.models.args_jigen import add_args2parser_jigen
 from domainlab.models.args_vae import add_args2parser_vae
+from domainlab.utils.logger import Logger
 
 
 def mk_parser_main():
@@ -201,14 +201,15 @@ def parse_cmd_args():
     """
     parser = mk_parser_main()
     args = parser.parse_args()
+    logger = Logger.get_logger(logger_name='main_out_logger', loglevel='DEBUG')
     if args.config_file:
         data = yaml.safe_load(args.config_file)
         delattr(args, 'config_file')
         apply_dict_to_args(args, data)
 
     if args.acon is None and args.bm_dir is None:
-        print("\n\n")
-        warnings.warn("no algorithm conf specified, going to use default")
-        print("\n\n")
+        logger.warning("\n\n")
+        logger.warning("no algorithm conf specified, going to use default")
+        logger.warning("\n\n")
 
     return args

--- a/domainlab/arg_parser.py
+++ b/domainlab/arg_parser.py
@@ -156,6 +156,9 @@ def mk_parser_main():
     arg_group_task.add_argument('--san_num', type=int, default=8,
                                 help='number of images to be dumped for the sanity check')
 
+    arg_group_task.add_argument('--loglevel', type=str, default='INFO',
+                                help='sets the loglevel of the logger')
+
     # args for variational auto encoder
     arg_group_vae = parser.add_argument_group('vae')
     arg_group_vae = add_args2parser_vae(arg_group_vae)
@@ -201,7 +204,7 @@ def parse_cmd_args():
     """
     parser = mk_parser_main()
     args = parser.parse_args()
-    logger = Logger.get_logger(logger_name='main_out_logger', loglevel='DEBUG')
+    logger = Logger.get_logger(logger_name='main_out_logger', loglevel=args['loglevel'])
     if args.config_file:
         data = yaml.safe_load(args.config_file)
         delattr(args, 'config_file')

--- a/domainlab/compos/exp/exp_main.py
+++ b/domainlab/compos/exp/exp_main.py
@@ -11,6 +11,7 @@ from domainlab.compos.exp.exp_utils import AggWriter
 from domainlab.tasks.zoo_tasks import TaskChainNodeGetter
 from domainlab.dsets.utils_data import plot_ds
 from domainlab.utils.sanity_check import SanityCheck
+from domainlab.utils.logger import Logger
 
 os.environ['CUDA_LAUNCH_BLOCKING'] = "1"  # debug
 
@@ -44,27 +45,28 @@ class Exp():
         check performance by loading persisted model
         """
         t_0 = datetime.datetime.now()
-        print('\n Experiment start at :', str(t_0))
+        logger = Logger.get_logger()
+        logger.info('\n Experiment start at :', str(t_0))
         t_c = t_0
         self.trainer.before_tr()
         for epoch in range(1, self.epochs + 1):
             t_before_epoch = t_c
             flag_stop = self.trainer.tr_epoch(epoch)
             t_c = datetime.datetime.now()
-            print(f"epoch: {epoch} ",
-                  "now: ", str(t_c),
-                  "epoch time: ", t_c - t_before_epoch,
-                  "used: ", t_c - t_0,
-                  "model: ", self.visitor.model_name)
+            logger.info(f"epoch: {epoch} ",
+                        "now: ", str(t_c),
+                        "epoch time: ", t_c - t_before_epoch,
+                        "used: ", t_c - t_0,
+                        "model: ", self.visitor.model_name)
             # current time, time since experiment start, epoch time
             if flag_stop:
                 self.epoch_counter = epoch
-                print("early stop trigger")
+                logger.info("early stop trigger")
                 break
             if epoch == self.epochs:
                 self.epoch_counter = self.epochs
             else:
                 self.epoch_counter += 1
-        print("Experiment finished at epoch:", self.epoch_counter,
-              "with time:", t_c - t_0, "at", t_c)
+        logger.info("Experiment finished at epoch:", self.epoch_counter,
+                    "with time:", t_c - t_0, "at", t_c)
         self.trainer.post_tr()

--- a/domainlab/compos/exp/exp_utils.py
+++ b/domainlab/compos/exp/exp_utils.py
@@ -10,6 +10,7 @@ import torch
 
 from sklearn.metrics import ConfusionMatrixDisplay
 from domainlab.utils.get_git_tag import get_git_tag
+from domainlab.utils.logger import Logger
 
 
 
@@ -62,7 +63,8 @@ class ExpModelPersistVisitor():
         model_name = "_".join(list4mname)
         if self.host.args.debug:
             model_name = "debug_" + model_name
-        print("model name:", model_name)
+        logger = Logger.get_logger()
+        logger.info("model name:", model_name)
         return model_name
 
     def save(self, model, suffix=None):
@@ -178,9 +180,10 @@ class AggWriter(ExpModelPersistVisitor):
         """
         file_path = self.get_fpath()
         Path(os.path.dirname(file_path)).mkdir(parents=True, exist_ok=True)
-        print("results aggregation path:", file_path)
+        logger = Logger.get_logger()
+        logger.info("results aggregation path:", file_path)
         with open(file_path, 'a', encoding="utf8") as f_h:
-            print(str_line, file=f_h)
+            logger.info(str_line, file=f_h)
 
     def confmat_to_file(self, confmat, confmat_filename):
         """Save confusion matrix as a figure
@@ -199,7 +202,8 @@ class AggWriter(ExpModelPersistVisitor):
         # configuration file in the future.
         confmat_filename = confmat_filename.removeprefix("mname_")
         file_path = os.path.join(os.path.dirname(file_path), f"{confmat_filename}_conf_mat.png")
-        print("confusion matrix saved in file: ", file_path)
+        logger = Logger.get_logger()
+        logger.info("confusion matrix saved in file: ", file_path)
         disp.figure_.savefig(file_path)
 
 

--- a/domainlab/compos/nn_zoo/nn_alex.py
+++ b/domainlab/compos/nn_zoo/nn_alex.py
@@ -3,6 +3,7 @@ from torchvision import models as torchvisionmodels
 
 from domainlab.compos.nn_zoo.nn import LayerId
 from domainlab.compos.nn_zoo.nn_torchvision import NetTorchVisionBase
+from domainlab.utils.logger import Logger
 
 
 class AlexNetBase(NetTorchVisionBase):
@@ -49,10 +50,11 @@ class Alex4DeepAll(AlexNetBase):
     def __init__(self, flag_pretrain, dim_y):
         super().__init__(flag_pretrain)
         if self.net_torchvision.classifier[6].out_features != dim_y:
-            print("original alex net out dim", self.net_torchvision.classifier[6].out_features)
+            logger = Logger.get_logger()
+            logger.info("original alex net out dim", self.net_torchvision.classifier[6].out_features)
             num_ftrs = self.net_torchvision.classifier[6].in_features
             self.net_torchvision.classifier[6] = nn.Linear(num_ftrs, dim_y)
-            print("re-initialized to ", dim_y)
+            logger.info("re-initialized to ", dim_y)
 
 
 class AlexNetNoLastLayer(AlexNetBase):

--- a/domainlab/compos/nn_zoo/nn_torchvision.py
+++ b/domainlab/compos/nn_zoo/nn_torchvision.py
@@ -1,4 +1,5 @@
 import torch.nn as nn
+from domainlab.utils.logger import Logger
 
 
 class NetTorchVisionBase(nn.Module):
@@ -26,4 +27,5 @@ class NetTorchVisionBase(nn.Module):
         """
         for name, param in self.net_torchvision.named_parameters():
             if param.requires_grad:
-                print("layers that will be optimized: \t", name)
+                logger = Logger.get_logger()
+                logger.info("layers that will be optimized: \t", name)

--- a/domainlab/compos/pcr/p_chain_handler.py
+++ b/domainlab/compos/pcr/p_chain_handler.py
@@ -3,6 +3,7 @@
 __author__ = "Xudong Sun"
 
 import abc
+from domainlab.utils.logger import Logger
 
 
 class Request4Chain(metaclass=abc.ABCMeta):
@@ -83,12 +84,14 @@ class AbstractChainNodeHandler(metaclass=abc.ABCMeta):
         if self._success_node is not None:
             return self._success_node.handle(request)
         err_msg = str(request) + " does not exist"
-        print("available options are")
+        logger = Logger.get_logger()
+        logger.info("available options are")
         self.print_options()
         raise NotImplementedError(err_msg)
 
     def print_options(self):
-        print(self.__class__.__name__)
+        logger = Logger.get_logger()
+        logger.info(self.__class__.__name__)
         if self._parent_node is not None:
             self._parent_node.print_options()
 

--- a/domainlab/dsets/dset_subfolder.py
+++ b/domainlab/dsets/dset_subfolder.py
@@ -9,6 +9,7 @@ from typing import Any, Tuple
 
 from torchvision.datasets import DatasetFolder
 from rich import print as rprint
+from domainlab.utils.logger import Logger
 
 def has_file_allowed_extension(filename: str, extensions: Tuple[str, ...]) -> bool:
     """
@@ -114,10 +115,11 @@ class DsetSubFolder(DatasetFolder):
         Ensures:
             No class is a submdirectory of another.
         """
+        logger = Logger.get_logger()
         if sys.version_info >= (3, 5):
             # Faster and available in Python 3.5 and above
             list_subfolders = [subfolder.name for subfolder in list(os.scandir(mdir))]
-            rprint("list of subfolders", list_subfolders)
+            logger.info(rprint("list of subfolders", list_subfolders))
             classes = [d.name for d in os.scandir(mdir) \
                        if d.is_dir() and d.name in self.list_class_dir]
         else:
@@ -125,8 +127,8 @@ class DsetSubFolder(DatasetFolder):
                        if os.path.isdir(os.path.join(mdir, d)) and d in self.list_class_dir]
         flag_user_input_classes_in_folder = (set(self.list_class_dir) <= set(classes))
         if not flag_user_input_classes_in_folder:
-            print("user provided class names:", self.list_class_dir)
-            print("subfolder names from folder:", mdir, classes)
+            logger.info("user provided class names:", self.list_class_dir)
+            logger.info("subfolder names from folder:", mdir, classes)
             raise RuntimeError("user provided class names does not match the subfolder names")
         classes.sort()
         class_to_idx = {classes[i]: i for i in range(len(classes))}

--- a/domainlab/dsets/utils_data.py
+++ b/domainlab/dsets/utils_data.py
@@ -8,6 +8,7 @@ import torch.utils.data as data_utils
 from PIL import Image
 from torch.utils.data import Dataset
 from torchvision.utils import save_image
+from domainlab.utils.logger import Logger
 
 
 def fun_img_path_loader_default(path):
@@ -73,13 +74,14 @@ class DsetInMemDecorator(Dataset):
         """
         self.dset = dset
         self.item_list = []
+        logger = Logger.get_logger()
         if name is not None:
-            print("loading dset ", name)
+            logger.info("loading dset ", name)
         t_0 = datetime.datetime.now()
         for i in range(len(self.dset)):
             self.item_list.append(self.dset[i])
         t_1 = datetime.datetime.now()
-        print("loading dataset to memory taken: ", t_1-t_0)
+        logger.info("loading dataset to memory taken: ", t_1-t_0)
 
     def __getitem__(self, idx):
         """

--- a/domainlab/exp_protocol/aggregate_results.py
+++ b/domainlab/exp_protocol/aggregate_results.py
@@ -7,6 +7,7 @@ import os
 from typing import List
 
 from domainlab.utils.generate_benchmark_plots import gen_benchmark_plots
+from domainlab.utils.logger import Logger
 
 
 def agg_results(input_files: List[str], output_file: str):
@@ -20,7 +21,8 @@ def agg_results(input_files: List[str], output_file: str):
     """
     os.makedirs(os.path.dirname(output_file), exist_ok=True)
     has_header = False
-    # print(f"exp_results={input.exp_results}")
+    logger = Logger.get_logger()
+    logger.debug(f"exp_results={input.exp_results}")
     with open(output_file, 'w') as out_stream:
         for res in input_files:
             with open(res, 'r') as in_stream:

--- a/domainlab/exp_protocol/benchmark.smk
+++ b/domainlab/exp_protocol/benchmark.smk
@@ -55,7 +55,10 @@ rule parameter_sampling:
     run:
         from domainlab.utils.hyperparameter_sampling import sample_hyperparameters
 
-        Logger.get_logger(logger_name='benchmark_logger', loglevel='DEBUG')
+        if 'loglevel' in config.keys():
+            Logger.get_logger(logger_name='benchmark_logger', loglevel=config['loglevel'])
+        else:
+            Logger.get_logger(logger_name='benchmark_logger', loglevel='INFO')
 
         sampling_seed_str = params.sampling_seed
         if isinstance(sampling_seed_str, str) and (len(sampling_seed_str) > 0):

--- a/domainlab/exp_protocol/benchmark.smk
+++ b/domainlab/exp_protocol/benchmark.smk
@@ -2,6 +2,8 @@ import os
 import sys
 from pathlib import Path
 
+from domainlab.utils.logger import Logger
+
 try:
     config_path = workflow.configfiles[0]
 except IndexError:
@@ -35,8 +37,9 @@ def experiment_result_files(_):
                 num_nonsample_tasks += 1
     # total number of hyperparameter samples
     total_num_params = config['num_param_samples'] * num_sample_tasks + num_nonsample_tasks
-    print(f"total_num_params={total_num_params}")
-    print(f"={config['num_param_samples']} * {num_sample_tasks} + {num_nonsample_tasks}")
+    logger = Logger.get_logger()
+    logger.info(f"total_num_params={total_num_params}")
+    logger.info(f"={config['num_param_samples']} * {num_sample_tasks} + {num_nonsample_tasks}")
     return [f"{config['output_dir']}/rule_results/{i}.csv" for i in range(total_num_params)]
 
 
@@ -51,6 +54,8 @@ rule parameter_sampling:
         sampling_seed=os.environ["DOMAINLAB_CUDA_HYPERPARAM_SEED"]
     run:
         from domainlab.utils.hyperparameter_sampling import sample_hyperparameters
+
+        Logger.get_logger(logger_name='benchmark_logger', loglevel='DEBUG')
 
         sampling_seed_str = params.sampling_seed
         if isinstance(sampling_seed_str, str) and (len(sampling_seed_str) > 0):

--- a/domainlab/exp_protocol/run_experiment.py
+++ b/domainlab/exp_protocol/run_experiment.py
@@ -12,6 +12,7 @@ from domainlab.arg_parser import mk_parser_main, apply_dict_to_args
 from domainlab.compos.exp.exp_cuda_seed import set_seed
 from domainlab.compos.exp.exp_main import Exp
 from domainlab.compos.exp.exp_utils import ExpProtocolAggWriter
+from domainlab.utils.logger import Logger
 
 
 def load_parameters(file: str, index: int) -> tuple:
@@ -58,9 +59,10 @@ def run_experiment(
     if misc is None:
         misc = {}
     str_algo_as_task, hyperparameters = load_parameters(param_file, param_index)
-    # print("\n*******************************************************************")
-    # print(f"{str_algo_as_task}, param_index={param_index}, params={hyperparameters}")
-    # print("*******************************************************************\n")
+    logger = Logger.get_logger()
+    logger.debug("\n*******************************************************************")
+    logger.debug(f"{str_algo_as_task}, param_index={param_index}, params={hyperparameters}")
+    logger.debug("*******************************************************************\n")
     misc['result_file'] = out_file
     misc['params'] = hyperparameters
     misc['benchmark_task_name'] = str_algo_as_task
@@ -83,8 +85,8 @@ def run_experiment(
 
     if torch.cuda.is_available():
         torch.cuda.init()
-        print("before experiment loop: ")
-        print(torch.cuda.memory_summary())
+        logger.info("before experiment loop: ")
+        logger.info(torch.cuda.memory_summary())
     if start_seed is None:
         start_seed = config['startseed']
         end_seed = config['endseed']
@@ -98,10 +100,10 @@ def run_experiment(
             args.seed = seed
             try:
                 if torch.cuda.is_available():
-                    print("before experiment starts")
-                    print(torch.cuda.memory_summary())
+                    logger.info("before experiment starts")
+                    logger.info(torch.cuda.memory_summary())
             except KeyError as ex:
-                print(ex)
+                logger.error(ex)
             args.lr = float(args.lr)
             # <=' not supported between instances of 'float' and 'str
             exp = Exp(args=args, visitor=ExpProtocolAggWriter)
@@ -109,16 +111,16 @@ def run_experiment(
                 exp.execute()
             try:
                 if torch.cuda.is_available():
-                    print("before torch memory clean up")
-                    print(torch.cuda.memory_summary())
+                    logger.info("before torch memory clean up")
+                    logger.info(torch.cuda.memory_summary())
             except KeyError as ex:
-                print(ex)
+                logger.error(ex)
             del exp
             torch.cuda.empty_cache()
             gc.collect()
             try:
                 if torch.cuda.is_available():
-                    print("after torch memory clean up")
-                    print(torch.cuda.memory_summary())
+                    logger.info("after torch memory clean up")
+                    logger.info(torch.cuda.memory_summary())
             except KeyError as ex:
-                print(ex)
+                logger.error(ex)

--- a/domainlab/tasks/a_task.py
+++ b/domainlab/tasks/a_task.py
@@ -1,11 +1,11 @@
 """
 Abstract class for Task
 """
-import warnings
 from abc import abstractmethod
 
 from domainlab.compos.pcr.p_chain_handler import AbstractChainNodeHandler
 from domainlab.tasks.task_utils import parse_domain_id
+from domainlab.utils.logger import Logger
 
 
 class NodeTaskDG(AbstractChainNodeHandler):
@@ -146,7 +146,8 @@ class NodeTaskDG(AbstractChainNodeHandler):
                 subset of available domains {list_domains}")
 
         if set(list_domain_tr) & set(list_domain_te):
-            warnings.warn(
+            logger = Logger.get_logger()
+            logger.warning(
                 "The sets of training and test domains overlap -- \
                 be aware of data leakage or training to the test!",
                 RuntimeWarning

--- a/domainlab/tasks/task_folder.py
+++ b/domainlab/tasks/task_folder.py
@@ -9,6 +9,7 @@ from domainlab.dsets.utils_data import (DsetInMemDecorator,
                                         mk_fun_label2onehot)
 from domainlab.tasks.b_task_classif import NodeTaskDictClassif
 from domainlab.tasks.utils_task import DsetClassVecDecoratorImgPath
+from domainlab.utils.logger import Logger
 
 
 class NodeTaskFolder(NodeTaskDictClassif):
@@ -71,7 +72,8 @@ class NodeTaskFolderClassNaMismatch(NodeTaskFolder):
         if float(args.split):
             raise RuntimeError(
                 "this task does not support spliting training domain yet")
-        print("reading domain:", na_domain)
+        logger = Logger.get_logger()
+        logger.info("reading domain:", na_domain)
         domain_class_dirs = \
             self._dict_domain_folder_name2class[na_domain].keys()
         if self._dict_domain_img_trans:

--- a/domainlab/tasks/zoo_tasks.py
+++ b/domainlab/tasks/zoo_tasks.py
@@ -7,6 +7,7 @@ from domainlab.tasks.task_folder_mk import mk_task_folder
 from domainlab.tasks.task_mnist_color import NodeTaskMNISTColor10
 from domainlab.tasks.utils_task import ImSize
 from domainlab.utils.u_import import import_path
+from domainlab.utils.logger import Logger
 
 path_this_file = os.path.dirname(os.path.realpath(__file__))
 
@@ -74,11 +75,12 @@ class TaskChainNodeGetter(object):
             chain.set_parent(node)
             chain = node
             if self.args.task is None:
-                print("")
-                print("overriding args.task ",
-                      self.args.task, " to  ",
-                      node.task_name)
-                print("")
+                logger = Logger.get_logger()
+                logger.info("")
+                logger.info("overriding args.task ",
+                            self.args.task, " to  ",
+                            node.task_name)
+                logger.info("")
                 self.request = node.task_name  # @FIXME
         node = chain.handle(self.request)
         return node

--- a/domainlab/utils/generate_benchmark_plots.py
+++ b/domainlab/utils/generate_benchmark_plots.py
@@ -8,6 +8,7 @@ import matplotlib
 import pandas as pd
 import seaborn as sns
 import numpy as np
+from domainlab.utils.logger import Logger
 
 matplotlib.use('Agg')
 
@@ -109,8 +110,9 @@ def gen_plots(dataframe: pd.DataFrame, output_dir: str, use_param_index: bool):
                 scatterplot(dataframe, [obj_i, obj[j]],
                             file=output_dir + '/scatterpl/' + obj_i + '_' + obj[j] + '.png')
             except IndexError:
-                print(f'WARNING: disabling kde because cov matrix is singular for objectives '
-                      f'{obj_i} & {obj[j]}')
+                logger = Logger.get_logger()
+                logger.warning(f'disabling kde because cov matrix is singular for objectives '
+                               f'{obj_i} & {obj[j]}')
                 scatterplot(dataframe, [obj_i, obj[j]],
                             file=output_dir + '/scatterpl/' + obj_i + '_' + obj[j] + '.png',
                             kde=False)
@@ -155,8 +157,9 @@ def gen_plots(dataframe: pd.DataFrame, output_dir: str, use_param_index: bool):
                                 '/scatterpl/' + obj_i + '_' + obj[j] + '.png',
                                 distinguish_hyperparam=True)
                 except IndexError:
-                    print(f'WARNING: disabling kde because cov matrix is singular for objectives '
-                          f'{obj_i} & {obj[j]}')
+                    logger = Logger.get_logger()
+                    logger.warning(f'WARNING: disabling kde because cov matrix is singular for objectives '
+                                   f'{obj_i} & {obj[j]}')
                     scatterplot(dataframe_algo, [obj_i, obj[j]],
                                 file=output_dir + '/' + str(algorithm) +
                                 '/scatterpl/' + obj_i + '_' + obj[j] + '.png',

--- a/domainlab/utils/get_git_tag.py
+++ b/domainlab/utils/get_git_tag.py
@@ -1,33 +1,37 @@
 import subprocess
-import warnings
 from subprocess import CalledProcessError
+
+from domainlab.utils.logger import Logger
 
 
 def get_git_tag(print_diff=False):
     flag_not_commited = False
+    logger = Logger.get_logger()
     try:
         subprocess.check_output(
             ['git', 'diff-index', '--quiet', 'HEAD'])
     except CalledProcessError:
-        print("\n\n")
-        warnings.warn("!!!: not committed yet")
+        logger.warning("\n\n")
+        logger.warning("!!!: not committed yet")
         flag_not_commited = True
-        print("\n\n")
+        logger.warning("\n\n")
         try:
             diff_byte = subprocess.check_output(['git', 'diff'])
             if print_diff:
-                print(diff_byte)  # print is currently ugly, do not use!
+                logger.info(diff_byte)  # print is currently ugly, do not use!
         except Exception:
-            warnings.warn("not in a git repository")
+            logger = Logger.get_logger()
+            logger.warning("not in a git repository")
     try:
         tag_byte = subprocess.check_output(
             ["git", "describe", "--always"]).strip()
-        print(tag_byte)
+        logger.info(tag_byte)
         tag_str = str(tag_byte)
         git_str = tag_str.replace("'", "")
         if flag_not_commited:
             git_str = git_str + "_not_commited"
         return git_str
     except Exception:
-        warnings.warn("not in a git repository")
+        logger = Logger.get_logger()
+        logger.warning("not in a git repository")
     return "no_git_version"

--- a/domainlab/utils/hyperparameter_sampling.py
+++ b/domainlab/utils/hyperparameter_sampling.py
@@ -14,6 +14,8 @@ from ast import literal_eval   # literal_eval can safe evaluate python expressio
 import numpy as np
 import pandas as pd
 
+from domainlab.utils.logger import Logger
+
 
 class Hyperparameter:
     """
@@ -182,7 +184,8 @@ def check_constraints(params: List[Hyperparameter], constraints) -> bool:
                 setattr(par, 'val', eval(par.reference))
                 # NOTE: literal_eval will cause ValueError: malformed node or string
             except Exception as ex:
-                print(f"error in evaluating expression: {par.reference}")
+                logger = Logger.get_logger()
+                logger.info(f"error in evaluating expression: {par.reference}")
                 raise ex
             locals().update({par.name: par.val})
 

--- a/domainlab/utils/logger.py
+++ b/domainlab/utils/logger.py
@@ -1,12 +1,25 @@
+'''
+A logger for our software
+'''
 import os
 import logging
 
 
 class Logger:
+    '''
+    static logger class
+    '''
     logger = None
 
     @staticmethod
     def get_logger(logger_name='logger', loglevel='INFO'):
+        '''
+        returns a logger
+        if no logger was created yet, it will create a logger with the name
+        specified in logger_name with the level specified in loglevel.
+        If the logger was created for the first time the arguments do not change
+        anything at the behaviour anymore
+        '''
         if Logger.logger is None:
             Logger.logger = logging.getLogger(logger_name)
             Logger.logger.setLevel(loglevel)

--- a/domainlab/utils/logger.py
+++ b/domainlab/utils/logger.py
@@ -6,7 +6,7 @@ class Logger:
     logger = None
 
     @staticmethod
-    def get_logger(logger_name='logger', loglevel='DEBUG'):
+    def get_logger(logger_name='logger', loglevel='INFO'):
         if Logger.logger is None:
             Logger.logger = logging.getLogger(logger_name)
             Logger.logger.setLevel(loglevel)
@@ -17,7 +17,7 @@ class Logger:
             # Create handlers and set their logging level
             filehandler = logging.FileHandler(logfolder + '/' + Logger.logger.name + '.log',
                                               mode='w')
-            filehandler.setLevel('DEBUG')
+            filehandler.setLevel(loglevel)
             # Add handlers to logger
             Logger.logger.addHandler(filehandler)
         return Logger.logger

--- a/domainlab/utils/logger.py
+++ b/domainlab/utils/logger.py
@@ -1,0 +1,23 @@
+import os
+import logging
+
+
+class Logger:
+    logger = None
+
+    @staticmethod
+    def get_logger(logger_name='logger', loglevel='DEBUG'):
+        if Logger.logger is None:
+            Logger.logger = logging.getLogger(logger_name)
+            Logger.logger.setLevel(loglevel)
+
+            # Create handlers and set their logging level
+            logfolder = 'zoutput/logs'
+            os.makedirs(logfolder, exist_ok=True)
+            # Create handlers and set their logging level
+            filehandler = logging.FileHandler(logfolder + '/' + Logger.logger.name + '.log',
+                                              mode='w')
+            filehandler.setLevel('DEBUG')
+            # Add handlers to logger
+            Logger.logger.addHandler(filehandler)
+        return Logger.logger

--- a/domainlab/utils/u_import_net_module.py
+++ b/domainlab/utils/u_import_net_module.py
@@ -3,6 +3,7 @@ import external neural network implementation
 """
 
 from domainlab.utils.u_import import import_path
+from domainlab.utils.logger import Logger
 
 
 def build_external_obj_net_module_feat_extract(mpath, dim_y,
@@ -33,8 +34,9 @@ def build_external_obj_net_module_feat_extract(mpath, dim_y,
         try:
             net = getattr(net_module, name_fun)(dim_y, remove_last_layer)
         except Exception:
-            print("function %s should return a neural network (pytorch module) that \
-                   that extract features from an image" % (name_signature))
+            logger = Logger.get_logger()
+            logger.error("function %s should return a neural network (pytorch module) that \
+                         that extract features from an image" % (name_signature))
             raise
         if net is None:
             raise RuntimeError("the pytorch module returned by %s is None"

--- a/domainlab/utils/utils_cuda.py
+++ b/domainlab/utils/utils_cuda.py
@@ -2,6 +2,7 @@
 choose devices
 """
 import torch
+from domainlab.utils.logger import Logger
 
 
 def get_device(args):
@@ -14,7 +15,8 @@ def get_device(args):
         device = torch.device("cuda" if flag_cuda else "cpu")
     else:
         device = torch.device("cuda:"+args.device if flag_cuda else "cpu")
-    print("")
-    print("using device:", str(device))
-    print("")
+    logger = Logger.get_logger()
+    logger.info("")
+    logger.info("using device:", str(device))
+    logger.info("")
     return device

--- a/domainlab/utils/utils_img_sav.py
+++ b/domainlab/utils/utils_img_sav.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 from torchvision.utils import make_grid, save_image
+from domainlab.utils.logger import Logger
 
 
 def mk_fun_sav_img(path=".", nrow=8, folder_na=""):
@@ -14,7 +15,8 @@ def mk_fun_sav_img(path=".", nrow=8, folder_na=""):
     def my_sav_img(comparison_tensor_stack, name, title=None):
         f_p = os.path.join(path, folder_na, name)
         Path(os.path.dirname(f_p)).mkdir(parents=True, exist_ok=True)
-        print("saving to ", f_p)
+        logger = Logger.get_logger()
+        logger.info("saving to ", f_p)
         # works also if tensor is already in cpu
         tensor = comparison_tensor_stack.cpu()
         if title is None:

--- a/main_out.py
+++ b/main_out.py
@@ -2,6 +2,7 @@ from domainlab.arg_parser import parse_cmd_args
 from domainlab.compos.exp.exp_cuda_seed import set_seed  # reproducibility
 from domainlab.compos.exp.exp_main import Exp
 from domainlab.exp_protocol import aggregate_results
+from domainlab.utils.logger import Logger
 
 if __name__ == "__main__":
     args = parse_cmd_args()


### PR DESCRIPTION
will solve #131 

The logger is defined in a static class. 

When first calling `Logger.getlogger(logger_name=... , loglevel=...)` it will create a logger with the specified name and loglevel. In each later call it will just return the logger which is already created. The logger will write inside a file in `zoutput/logs`