### PR TITLE
bugfix benchmarkyaml

### DIFF
--- a/domainlab/exp_protocol/benchmark.smk
+++ b/domainlab/exp_protocol/benchmark.smk
@@ -37,6 +37,7 @@ def experiment_result_files(_):
                 num_nonsample_tasks += 1
     # total number of hyperparameter samples
     logger = Logger.get_logger()
+    #TODO this needs to be known before the hyperparameters are sampled
     hyperparam_df = pd.read_csv(f'{config["output_dir"]}/hyperparameters.csv')
     total_num_params = hyperparam_df.shape[0]
     #total_num_params = config['num_param_samples'] * num_sample_tasks + num_nonsample_tasks

--- a/domainlab/exp_protocol/benchmark.smk
+++ b/domainlab/exp_protocol/benchmark.smk
@@ -2,6 +2,8 @@ import os
 import sys
 from pathlib import Path
 
+import pandas as pd
+
 try:
     config_path = workflow.configfiles[0]
 except IndexError:
@@ -34,10 +36,13 @@ def experiment_result_files(_):
             else:
                 num_nonsample_tasks += 1
     # total number of hyperparameter samples
-    total_num_params = config['num_param_samples'] * num_sample_tasks + num_nonsample_tasks
     logger = Logger.get_logger()
+    hyperparam_df = pd.read_csv(f'{config["output_dir"]}/hyperparameters.csv')
+    total_num_params = hyperparam_df.shape[0]
+    #total_num_params = config['num_param_samples'] * num_sample_tasks + num_nonsample_tasks
     logger.info(f"total_num_params={total_num_params}")
-    logger.info(f"={config['num_param_samples']} * {num_sample_tasks} + {num_nonsample_tasks}")
+    #logger.info(f"={config['num_param_samples']} * {num_sample_tasks} + {num_nonsample_tasks}")
+
     return [f"{config['output_dir']}/rule_results/{i}.csv" for i in range(total_num_params)]
 
 
@@ -54,25 +59,29 @@ rule parameter_sampling:
         from domainlab.utils.hyperparameter_sampling import sample_hyperparameters
         from domainlab.utils.hyperparameter_gridsearch import sample_gridsearch
 
-        sampling_seed_str = params.sampling_seed
-        if isinstance(sampling_seed_str, str) and (len(sampling_seed_str) > 0):
-          # hash will keep integer intact and hash strings to random seed
-          # hased integer is signed and usually too big, random seed only
-          # allowed to be in [0, 2^32-1]
-          # if the user input is number, then hash will not change the value,
-          # so we recommend the user to use number as start seed
-          if sampling_seed_str.isdigit():
-            sampling_seed = int(sampling_seed_str)
-          else:
-            sampling_seed = abs(hash(sampling_seed_str)) % (2 ** 32)
-        elif 'sampling_seed' in config.keys():
-          sampling_seed = config['sampling_seed']
-        else:
-          sampling_seed = None
+        # for gridsearch there is no random component, therefore no
+        # random seed is needed
         if 'mode' in config.keys():  # type(config)=dict
             if config['mode'] == 'grid':
-                sample_gridsearch(config,str(output.dest),sampling_seed)
+                sample_gridsearch(config,str(output.dest))
+        # for random sampling we need to consider a random seed
         else:
+            sampling_seed_str = params.sampling_seed
+            if isinstance(sampling_seed_str, str) and (len(sampling_seed_str) > 0):
+              # hash will keep integer intact and hash strings to random seed
+              # hased integer is signed and usually too big, random seed only
+              # allowed to be in [0, 2^32-1]
+              # if the user input is number, then hash will not change the value,
+              # so we recommend the user to use number as start seed
+              if sampling_seed_str.isdigit():
+                sampling_seed = int(sampling_seed_str)
+              else:
+                sampling_seed = abs(hash(sampling_seed_str)) % (2 ** 32)
+            elif 'sampling_seed' in config.keys():
+              sampling_seed = config['sampling_seed']
+            else:
+              sampling_seed = None
+
             sample_hyperparameters(config, str(output.dest), sampling_seed)
 
 
@@ -123,7 +132,8 @@ rule run_experiment:
         # in the resulting pandas dataframe
         # :param out_file: path to the output csv
         num_gpus = int(num_gpus_str)
-        run_experiment(config,str(input.param_file),index,str(output.out_file), start_seed, num_gpus=num_gpus)
+        run_experiment(config, str(input.param_file), index,str(output.out_file),
+            start_seed, num_gpus=num_gpus)
 
 
 rule agg_results:

--- a/domainlab/exp_protocol/benchmark.smk
+++ b/domainlab/exp_protocol/benchmark.smk
@@ -49,7 +49,10 @@ def experiment_result_files(_):
                 if 'hyperparameters' in val.keys():
                     num_sample_tasks += 1
                 else:
-                    num_nonsample_tasks += 1
+                    if 'shared' in val.keys():
+                        num_sample_tasks += 1
+                    else:
+                        num_nonsample_tasks += 1
         # total number of hyperparameter samples
         total_num_params = config['num_param_samples'] * num_sample_tasks + num_nonsample_tasks
         logger.info(f"total_num_params={total_num_params} for random sampling")

--- a/domainlab/utils/hyperparameter_gridsearch.py
+++ b/domainlab/utils/hyperparameter_gridsearch.py
@@ -242,8 +242,7 @@ def grid_task(grid_df: pd.DataFrame, task_name: str, config: dict):
 
 
 def sample_gridsearch(config: dict,
-                      dest: str = None,
-                      sampling_seed: int = None) -> pd.DataFrame:
+                      dest: str = None) -> pd.DataFrame:
     """
     create the hyperparameters grid according to the given
     config, which should be the dictionary of the full
@@ -256,9 +255,6 @@ def sample_gridsearch(config: dict,
     """
     if dest is None:
         dest = config['output_dir'] + os.sep + 'hyperparameters.csv'
-
-    if not sampling_seed is None:
-        np.random.seed(sampling_seed)
 
     logger = Logger.get_logger()
     samples = pd.DataFrame(columns=['task', 'algo', 'params'])

--- a/gen_doc.sh
+++ b/gen_doc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # sphinx-quickstart
-git checkout doc2
+git checkout doc
 git merge master -m "merge master"
 
 cd docs


### PR DESCRIPTION
The keyword num_parameter_samples is not needed for gridsearch. Using it will ead to missleading results, therefore we should remove it, but this leads us to an error when trying to compute the number of hyperparameter expected