### PR TITLE
make it easier to debug crashes

### DIFF
--- a/domainlab/exp_protocol/run_experiment.py
+++ b/domainlab/exp_protocol/run_experiment.py
@@ -103,6 +103,11 @@ def run_experiment(
     gpu_ind = param_index % num_gpus
     args.device = str(gpu_ind)
 
+    logger.info('*** begin args')
+    for k, v in vars(args).items():
+        logger.info(f'{k} : {v}')
+    logger.info('*** end args')
+
     if torch.cuda.is_available():
         torch.cuda.init()
         logger.info("before experiment loop: ")


### PR DESCRIPTION
this will print the value of all parameters before running an experiment, for example:

```
*** begin args
config_file : None
lr : 5e-5
gamma_reg : 0.1 
es : 1 
seed : 0 
nocu : False
device : 0 
gen : False
keep_model : False
epos : 200 
epo_te : 1 
debug : False
dmem : False
no_dump : True
trainer : fbopt
out : zoutput
dpath : zdpath
tpath : examples/tasks/task_pacs_path_list.py
npath : examples/nets/resnet50domainbed.py
npath_dom : examples/nets/resnet50domainbed.py
npath_argna2val : None
nname_argna2val : None
nname : None
nname_dom : None
apath : None
exptag : exptag
aggtag : aggtag
bm_dir : None
plot_data : None
outp_dir : zoutput/benchmarks/shell_benchmark
param_idx : True
msel : last
msel_tr_loss : task
aname : hduva
acon : None
task : None
bs : 64
split : 0
te_d : None
tr_d : None
san_check : True
san_num : 8
loglevel : DEBUG
zd_dim : 64
zx_dim : 0
zy_dim : 64
topic_dim : 3
topic_h_dim : 8
img_h_dim : 8
nname_topic_distrib_img2topic : None
npath_topic_distrib_img2topic : examples/nets/resnet50domainbed.py
nname_encoder_sandwich_layer_img2h4zd : None
npath_encoder_sandwich_layer_img2h4zd : examples/nets/resnet50domainbed.py
gamma_y : 21500.0
gamma_d : None
beta_t : 1.0
beta_d : 1.0
beta_x : 1.0
beta_y : 1.0
warmup : 100
tau : 0.05
epos_per_match_update : 5
epochs_ctr : None
nperm : 31
pperm : 0.7
jigen_ppath : None
grid_len : 3
dial_steps_perturb : 3
dial_noise_scale : 0.001
dial_lr : 0.003
dial_epsilon : 0.031
k_i_gain : 0.08330000000000001
mu_clip : 10000
coeff_ma : 0.5
exp_shoulder_clip : 10
ini_setpoint_ratio : 0.7500000000000002
no_tensorboard : False
init_mu4beta : 0.001
beta_mu : 1.1
delta_mu : None
budget_mu_per_step : 5
budget_theta_update_per_mu : 5
anchor_bar : False
myoptic_pareto : False
shared : ['ini_setpoint_ratio', 'k_i_gain', 'msel_tr_loss', 'msel', 'es', 'gamma_y']
result_file : zoutput/benchmarks/benchmark_fbopt_pacs_full/rule_results/924.csv
params : {'ini_setpoint_ratio': 0.7500000000000002, 'k_i_gain': 0.08330000000000001, 'msel': 'last', 'msel_tr_loss': 'task', 'es': 1, 'gamma_y': 21500.0}
benchmark_task_name : hduva_fbopt
param_index : 924
*** end args
```