### PR TITLE
no need to sample gamma_d in diva since it is registered in mu already

### DIFF
--- a/examples/benchmark/benchmark_fbopt_pacs_full.yaml
+++ b/examples/benchmark/benchmark_fbopt_pacs_full.yaml
@@ -107,7 +107,6 @@ diva_fbopt:
     - msel
     - es
     - gamma_y
-    - gamma_d
 
 hduva_fbopt:
   aname: hduva


### PR DESCRIPTION
@e-dorigatti , could you try some way to test if in the change i deleted gamma_d, if the benchmark still work?