### PR TITLE
Added backpack wrapper

### DIFF
--- a/domainlab/algos/trainers/backpack_wrapper.py
+++ b/domainlab/algos/trainers/backpack_wrapper.py
@@ -1,0 +1,23 @@
+import importlib
+
+class BackpackWrapper:
+    def __init__(self):
+        self.backpack = self._safe_import('backpack')
+        self.extend = self._safe_import('backpack.extend')
+        self.Variance = self._safe_import('backpack.extensions', 'Variance')
+
+    def _safe_import(self, module_name, attr=None):
+        try:
+            module = importlib.import_module(module_name)
+            return getattr(module, attr) if attr else module
+        except ImportError as e:
+            print(f"Could not import {module_name}: {e}")
+            return None
+
+    def extend_loss_function(self, loss_function):
+        if self.extend is not None:
+            return self.extend(loss_function)
+        else:
+            raise ImportError("Backpack extension not available.")
+
+


### PR DESCRIPTION
The idea is to use a wrapper around the backpack package. That way, whenever there are changes in the library, we only need to adjust the wrapper and not all occurrences in the code. <br>
It should also help with importing dynamically and not be used whenever the fishr trainer is not in use. 
Another option would be to refrain from using a wrapper and import backpack directly into the functions that use it by adding this directly to 'cal_dict_variance_grads' in: 
`` backpack = importlib.import_module('backpack')
    extend = importlib.import_module('backpack.extend')
    Variance = importlib.import_module('backpack.extensions').Variance``