### PR TITLE
Giving more information for subfolder read errors

### DIFF
--- a/domainlab/dsets/dset_subfolder.py
+++ b/domainlab/dsets/dset_subfolder.py
@@ -152,6 +152,8 @@ class DsetSubFolder(DatasetFolder):
         if not flag_user_input_classes_in_folder:
             logger.info(f"user provided class names: {self.list_class_dir}")
             logger.info(f"subfolder names from folder: {mdir} {classes}")
+            unmatched_names = set(self.list_class_dir) - set(classes)
+            logger.info(f"unmatched names: {unmatched_names}")
             raise RuntimeError(
                 "user provided class names does not match the subfolder names"
             )

--- a/domainlab/dsets/dset_subfolder.py
+++ b/domainlab/dsets/dset_subfolder.py
@@ -153,7 +153,7 @@ class DsetSubFolder(DatasetFolder):
             logger.info(f"user provided class names: {self.list_class_dir}")
             logger.info(f"subfolder names from folder: {mdir} {classes}")
             unmatched_names = set(self.list_class_dir) - set(classes)
-            logger.info(f"unmatched names: {unmatched_names}")
+            logger.info(f"unmatched class names provided by user: {unmatched_names}")
             raise RuntimeError(
                 "user provided class names does not match the subfolder names"
             )


### PR DESCRIPTION
I added a log to see which classes specified by the user don't match. 